### PR TITLE
Support animating webview when keyboard appears

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin was based on this Apache [project](https://github.com/apache/cordova
 - [Properties](#properties)
  - [Keyboard.isVisible](#keyboardisvisible)
  - [Keyboard.automaticScrollToTopOnHiding](#keyboardautomaticscrolltotoponhiding)
- - [Keyboard.onKeyboardAnimate](#keyboardanimate)
+ - [Keyboard.onKeyboardAnimate](#keyboardonkeyboardanimate)
 - [Events](#events)
  - [keyboardDidShow](#keyboarddidshow)
  - [keyboardDidHide](#keyboarddidhide)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This plugin was based on this Apache [project](https://github.com/apache/cordova
     - [Keyboard.disableScrollingInShrinkView](#keyboarddisablescrollinginshrinkview)
     - [Keyboard.hide](#keyboardhide)
     - [Keyboard.show](#keyboardshow)
+    - [Keyboard.setKeyboardAnimator](#keyboardsetkeyboardanimator)
 - [Properties](#properties)
     - [Keyboard.isVisible](#keyboardisvisible)
     - [Keyboard.automaticScrollToTopOnHiding](#keyboardautomaticscrolltotoponhiding)
-    - [Keyboard.onKeyboardAnimate](#keyboardonkeyboardanimate)
 - [Events](#events)
     - [keyboardDidShow](#keyboarddidshow)
     - [keyboardDidHide](#keyboarddidhide)
@@ -177,11 +177,11 @@ after keyboard is hiding.
 
 - iOS
 
-## Keyboard.onKeyboardAnimate
+## Keyboard.setKeyboardAnimator
 
 Assign a function that will handle content animation in the browser
 
-    Keyboard.onKeyboardAnimate = function(fromHeight, toHeight, animationDurationInMs, animationCompleteCallback)
+    Keyboard.setKeyboardAnimator(function(fromHeight, toHeight, animationDurationInMs, animationCompleteCallback)
     {    
         // Example with jQuery (http://jquery.com/) and Velocity.JS (http://julian.com/research/velocity/)
         $('body').velocity({height: [to, from]}, {duration: animationDurationInMS, easing: "easeOutQuad", complete: function()
@@ -189,7 +189,7 @@ Assign a function that will handle content animation in the browser
             // Tells the plugin that client side has finished animation
             animationCompleteCallback();
         }});
-    };
+    });
 
 #### Description
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ after keyboard is hiding.
 
 Assign a function that will handle content animation in the browser
 
-    Keyboard.onKeyboardAnimate = function(fromHeight, toHeight, animationDurationInMS, animationCompleteCallback)
+    Keyboard.onKeyboardAnimate = function(fromHeight, toHeight, animationDurationInMs, animationCompleteCallback)
     {    
         // Example with jQuery (http://jquery.com/) and Velocity.JS (http://julian.com/research/velocity/)
         $('body').velocity({height: [to, from]}, {duration: animationDurationInMS, easing: "easeOutQuad", complete: function()
@@ -199,7 +199,7 @@ Worth noting is that window.resize will be triggered after animation has been co
 This is due to the fact that the webview will resize after animation has been completed when the keyboard is appearing so that the animation is not clipped, and
 when the keyboard is hiding it will resize to the full height so that the animation out can be completed without clipping as well.
 
-Thanks to @glyuck for this approach from his project [GLKAnimateWebViewFrame](https://github.com/glyuck/GLKAnimateWebViewFrame) which is the base for this feature
+Thanks to [@glyuck](https://github.com/glyuck) for this approach from his project [GLKAnimateWebViewFrame](https://github.com/glyuck/GLKAnimateWebViewFrame) which is the base for this feature
 
 #### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This plugin was based on this Apache [project](https://github.com/apache/cordova
 - [Properties](#properties)
  - [Keyboard.isVisible](#keyboardisvisible)
  - [Keyboard.automaticScrollToTopOnHiding](#keyboardautomaticscrolltotoponhiding)
+ - [Keyboard.onKeyboardAnimate](#keyboardanimate)
 - [Events](#events)
  - [keyboardDidShow](#keyboarddidshow)
  - [keyboardDidHide](#keyboarddidhide)
@@ -169,6 +170,36 @@ Set this to true if you need that page scroll to beginning when keyboard is hidi
 This is allows to fix issue with elements declared with position: fixed,
 after keyboard is hiding.
 
+
+#### Supported Platforms
+
+- iOS
+
+## Keyboard.onKeyboardAnimate
+
+Assign a function that will handle content animation in the browser
+
+    Keyboard.onKeyboardAnimate = function(fromHeight, toHeight, animationDurationInMS, animationCompleteCallback)
+    {    
+        // Example with jQuery (http://jquery.com/) and Velocity.JS (http://julian.com/research/velocity/)
+        $('body').velocity({height: [to, from]}, {duration: animationDurationInMS, easing: "easeOutQuad", complete: function()
+        {
+            // Tells the plugin that client side has finished animation
+            animationCompleteCallback();
+        }});
+    };
+
+#### Description
+
+Assign a function that will handle animation when the keyboard appears and disappears.
+Remember to execute the provided callback to let the plugin know when animation has finished.
+The parameters given is which height the webview will animate from and to, the duration for which the keyboard will animate and a callback method to call when the animation has been completed.
+
+Worth noting is that window.resize will be triggered after animation has been completed when keyboard is showing, but before animation is started when hiding.
+This is due to the fact that the webview will resize after animation has been completed when the keyboard is appearing so that the animation is not clipped, and
+when the keyboard is hiding it will resize to the full height so that the animation out can be completed without clipping as well.
+
+Thanks to @glyuck for this approach from his project [GLKAnimateWebViewFrame](https://github.com/glyuck/GLKAnimateWebViewFrame) which is the base for this feature
 
 #### Supported Platforms
 

--- a/src/ios/CDVKeyboard.h
+++ b/src/ios/CDVKeyboard.h
@@ -35,7 +35,8 @@
 - (void)disableScrollingInShrinkView:(CDVInvokedUrlCommand*)command;
 - (void)hideFormAccessoryBar:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
-- (void)animationStart:(CDVInvokedUrlCommand *)command;
 - (void)animationComplete:(CDVInvokedUrlCommand *)command;
+- (void)enableAnimation:(CDVInvokedUrlCommand *)command;
+- (void)disableAnimation:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/CDVKeyboard.h
+++ b/src/ios/CDVKeyboard.h
@@ -39,5 +39,7 @@
 - (void)disableScrollingInShrinkView:(CDVInvokedUrlCommand*)command;
 - (void)hideFormAccessoryBar:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
+- (void)animationStart:(CDVInvokedUrlCommand *)command;
+- (void)animationComplete:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/CDVKeyboard.m
+++ b/src/ios/CDVKeyboard.m
@@ -79,14 +79,12 @@
                                             object:nil
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
-                                            NSLog(@"KeyboardShown");
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnShow();"];
                                         }];
     _keyboardHideObserver = [nc addObserverForName:UIKeyboardDidHideNotification
                                             object:nil
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
-                                            NSLog(@"KeyboardHidden");
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnHide();"];
                                         }];
 
@@ -94,7 +92,6 @@
                                                 object:nil
                                                  queue:[NSOperationQueue mainQueue]
                                             usingBlock:^(NSNotification* notification) {
-                                                NSLog(@"KeyboardWillShow");
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnShowing();"];
             weakSelf.keyboardIsVisible = YES;
                                             }];
@@ -102,7 +99,6 @@
                                                 object:nil
                                                  queue:[NSOperationQueue mainQueue]
                                             usingBlock:^(NSNotification* notification) {
-                                                NSLog(@"KeyboardWillHide");
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnHiding();"];
             weakSelf.keyboardIsVisible = NO;
                                             }];
@@ -213,7 +209,6 @@ static IMP WKOriginalImp;
     // even though keyboard is already visible, ignoring as early as possible
     if(newScreenHeight == self.webView.frame.size.height)
     {
-        NSLog(@"View supposed to change to same height, ignoring");
         if(_shouldAnimateWebView)
         {
             _shouldAnimateWebView = NO;
@@ -234,14 +229,12 @@ static IMP WKOriginalImp;
 
     // Tell JS that it can start animating with values
     NSString *javascriptString = [NSString stringWithFormat:@"Keyboard.beginAnimation(%f, %f, %f)", currentScreenHeight, newScreenHeight, duration*1000];
-    NSLog(@"Is changing webview, newScreenHeight: %f", newScreenHeight);
 
     BOOL isGrowing = newScreenHeight > currentScreenHeight;
 
     // If webView is growing, change it's frame imediately, so it's content is not clipped during animation
     if (isGrowing) {
         self.webView.frame = [self.webView.superview convertRect:screen fromView:self.webView];
-        NSLog(@"Frame changed before animation!");
     }
     [self.commandDelegate evalJs: javascriptString];
 
@@ -259,9 +252,7 @@ static IMP WKOriginalImp;
 //        // If webview was shrinking, change it's frame after animation is complete
 //        if (!isGrowing) {
 //            self.webView.frame = [self.webView.superview convertRect:screen fromView:self.webView];
-//            NSLog(@"Frame changed after animation!");
 //        }
-//        NSLog(@"Animation duration should be completed!");
 //    });
 }
 
@@ -318,29 +309,22 @@ static IMP WKOriginalImp;
 // JS indicates that it wants to handle Keyboard animation
 - (void)animationStart:(CDVInvokedUrlCommand *)command
 {
-    NSLog(@"animationStart");
     _shouldAnimateWebView = YES;
 }
 
 // JS indicates that it finished handling Keyboard animation
 - (void)animationComplete:(CDVInvokedUrlCommand*)command
 {
-    NSLog(@"animation Complete received");
     if(!_animationDetails)
     {
-        NSLog(@"no animation details available");
         return;
     }
-
-    NSLog(@"animation Complete received from %f to %f", [_animationDetails from] , [_animationDetails to]);
 
     BOOL isGrowing = [_animationDetails from] < [_animationDetails to];
     // If webview was shrinking, change it's frame after animation is complete
     if (!isGrowing) {
         self.webView.frame = [self.webView.superview convertRect:[_animationDetails screen] fromView:self.webView];
-        NSLog(@"Frame changed after animation!");
     }
-    NSLog(@"Animation duration should be completed!");
     _shouldAnimateWebView = NO;
     _animationDetails = nil;
 }

--- a/www/keyboard.js
+++ b/www/keyboard.js
@@ -22,7 +22,7 @@
 var argscheck = require('cordova/argscheck'),
     utils = require('cordova/utils'),
     exec = require('cordova/exec');
-   
+
 var Keyboard = function() {
 };
 
@@ -55,7 +55,7 @@ Keyboard.fireOnShow = function() {
     cordova.fireWindowEvent('keyboardDidShow');
 
     if(Keyboard.onshow) {
-	Keyboard.onshow();
+        Keyboard.onshow();
     }
 };
 
@@ -64,7 +64,16 @@ Keyboard.fireOnHide = function() {
     cordova.fireWindowEvent('keyboardDidHide');
 
     if(Keyboard.onhide) {
-	Keyboard.onhide();
+        Keyboard.onhide();
+    }
+};
+
+Keyboard.setKeyboardAnimator = function(animator) {
+    Keyboard.onKeyboardAnimate = animator;
+    if(typeof Keyboard.onKeyboardAnimate === "function") {
+        exec(null, null, "Keyboard", "enableAnimation", []);
+    } else {
+        exec(null, null, "Keyboard", "disableAnimation", []);
     }
 };
 
@@ -80,10 +89,7 @@ Keyboard.fireOnHiding = function() {
     cordova.fireWindowEvent('keyboardWillHide');
 
     if(Keyboard.onhiding) {
-	Keyboard.onhiding();
-    }
-    if(Keyboard.onKeyboardAnimate) {
-    animationStart();
+        Keyboard.onhiding();
     }
 };
 
@@ -91,10 +97,7 @@ Keyboard.fireOnShowing = function() {
     cordova.fireWindowEvent('keyboardWillShow');
 
     if(Keyboard.onshowing) {
-	Keyboard.onshowing();
-    }
-    if(Keyboard.onKeyboardAnimate) {
-    animationStart();
+        Keyboard.onshowing();
     }
 };
 
@@ -106,10 +109,6 @@ Keyboard.hide = function() {
     exec(null, null, "Keyboard", "hide", []);
 };
 
-var animationStart = function() {
-    exec(null, null, "Keyboard", "animationStart", []);
-};
-
 var animationComplete = function() {
     exec(null, null, "Keyboard", "animationComplete", []);
 };
@@ -117,8 +116,6 @@ var animationComplete = function() {
 Keyboard.beginAnimation = function(from, to, duration) {
     if(typeof Keyboard.onKeyboardAnimate === 'function') {
         Keyboard.onKeyboardAnimate(from, to, duration, animationComplete);
-    } else {
-        animationComplete();
     }
 };
 

--- a/www/keyboard.js
+++ b/www/keyboard.js
@@ -70,6 +70,10 @@ Keyboard.fireOnHiding = function() {
     if(Keyboard.onhiding) {
 	Keyboard.onhiding();
     }
+    if(typeof Keyboard.onKeyboardAnimate === 'function')
+    {
+        animationStart();
+    }
 };
 
 Keyboard.fireOnShowing = function() {
@@ -77,6 +81,10 @@ Keyboard.fireOnShowing = function() {
 
     if(Keyboard.onshowing) {
 	Keyboard.onshowing();
+    }
+    if(typeof Keyboard.onKeyboardAnimate === 'function')
+    {
+        animationStart();
     }
 };
 
@@ -88,6 +96,31 @@ Keyboard.hide = function() {
     exec(null, null, "Keyboard", "hide", []);
 };
 
+// Private animation handling
+var animationStart = function() {
+    console.log('JS: animationStart');
+    exec(null, null, "Keyboard", "animationStart", []);
+};
+
+var animationComplete = function() {
+    console.log('JS: animationComplete');
+    exec(null, null, "Keyboard", "animationComplete", []);
+};
+
+Keyboard.beginAnimation = function(from, to, duration) {
+    console.log('JS: beginAnimation');
+    if(typeof Keyboard.onKeyboardAnimate === 'function')
+    {
+        Keyboard.onKeyboardAnimate(from, to, duration, animationComplete);
+    }
+    else
+    {
+        animationComplete();
+    }
+};
+// End private animation handling
+
+Keyboard.onKeyboardAnimate = null;
 Keyboard.isVisible = false;
 Keyboard.automaticScrollToTopOnHiding = false;
 

--- a/www/keyboard.js
+++ b/www/keyboard.js
@@ -70,9 +70,8 @@ Keyboard.fireOnHiding = function() {
     if(Keyboard.onhiding) {
 	Keyboard.onhiding();
     }
-    if(typeof Keyboard.onKeyboardAnimate === 'function')
-    {
-        animationStart();
+    if(Keyboard.onKeyboardAnimate) {
+    animationStart();
     }
 };
 
@@ -82,9 +81,8 @@ Keyboard.fireOnShowing = function() {
     if(Keyboard.onshowing) {
 	Keyboard.onshowing();
     }
-    if(typeof Keyboard.onKeyboardAnimate === 'function')
-    {
-        animationStart();
+    if(Keyboard.onKeyboardAnimate) {
+    animationStart();
     }
 };
 
@@ -96,29 +94,21 @@ Keyboard.hide = function() {
     exec(null, null, "Keyboard", "hide", []);
 };
 
-// Private animation handling
 var animationStart = function() {
-    console.log('JS: animationStart');
     exec(null, null, "Keyboard", "animationStart", []);
 };
 
 var animationComplete = function() {
-    console.log('JS: animationComplete');
     exec(null, null, "Keyboard", "animationComplete", []);
 };
 
 Keyboard.beginAnimation = function(from, to, duration) {
-    console.log('JS: beginAnimation');
-    if(typeof Keyboard.onKeyboardAnimate === 'function')
-    {
+    if(typeof Keyboard.onKeyboardAnimate === 'function') {
         Keyboard.onKeyboardAnimate(from, to, duration, animationComplete);
-    }
-    else
-    {
+    } else {
         animationComplete();
     }
 };
-// End private animation handling
 
 Keyboard.onKeyboardAnimate = null;
 Keyboard.isVisible = false;


### PR DESCRIPTION
An attempt to fix #13 for iOS so that animation is possible while the keyboard appears and disappears. 

The approach is based on the project https://github.com/glyuck/GLKAnimateWebViewFrame with some modifications, and the only issue for me so far is that it seems like the webview content freezes for most of the time while animating the keyboard in, and then plays the whole animation. When the keyboard animates out the webview content seems to be able to animate as expected.

Comments and suggestions are appreciated.
