### PR TITLE
Account for blue status bar height when shrinking keyboard

### DIFF
--- a/src/ios/CDVKeyboard.m
+++ b/src/ios/CDVKeyboard.m
@@ -200,6 +200,12 @@ static IMP WKOriginalImp;
         self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView;
     }
 
+    // Check if the webview is offset due to the blue navigation status bar.
+    CGRect webviewFrame = [self.webView convertRect:[self.webView bounds] fromView:self.webView.superview];
+    float yOffset = webviewFrame.origin.y;
+    screen.origin.y -= yOffset;
+    screen.size.height += yOffset;
+
     // A view's frame is in its superview's coordinate system so we need to convert again
     self.webView.frame = [self.webView.superview convertRect:screen fromView:self.webView];
 }

--- a/src/ios/CDVKeyboard.m
+++ b/src/ios/CDVKeyboard.m
@@ -148,8 +148,7 @@ static IMP WKOriginalImp;
     // They removed this behavior is iOS 10, but for 8 and 9 we need to prevent the webview from listening on keyboard events
     // Even if you later set shrinkView to false, the observers will not be added back
     NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
-    if ([self.webView isKindOfClass:NSClassFromString(@"WKWebView")]
-        && ![[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){.majorVersion = 10, .minorVersion = 0, .patchVersion = 0 }]) {
+    if ([self.webView isKindOfClass:NSClassFromString(@"WKWebView")]) {
         [nc removeObserver:self.webView name:UIKeyboardWillHideNotification object:nil];
         [nc removeObserver:self.webView name:UIKeyboardWillShowNotification object:nil];
         [nc removeObserver:self.webView name:UIKeyboardWillChangeFrameNotification object:nil];


### PR DESCRIPTION
When you open up your app with a the blue navigation status bar, something (not sure what) offsets the view by the additional size of the larger statusbar (image 1).

However, when I open up the keyboard, the function that accounts for the shrinked view doesnt account for this offset (2) and when you close the keyboard, this issue remains (3).

However, with my fix, it all works (4) :)

(1)
![img_1731](https://user-images.githubusercontent.com/1794527/28232962-62cc3d08-68a8-11e7-9027-1e8a3a8566b1.PNG)

(2)
![img_1733](https://user-images.githubusercontent.com/1794527/28232960-62b7df20-68a8-11e7-93a4-9b4e1a5e2c90.PNG)

(3)
![img_1734](https://user-images.githubusercontent.com/1794527/28232961-62c03512-68a8-11e7-9158-0654a243181c.PNG)

(4)
![img_1732](https://user-images.githubusercontent.com/1794527/28232963-62d2b0f2-68a8-11e7-970c-c89c5f01d582.PNG)

