### PR TITLE
bug fixed: support iPad split screen

### DIFF
--- a/src/ios/CDVKeyboard.m
+++ b/src/ios/CDVKeyboard.m
@@ -173,7 +173,7 @@ static IMP WKOriginalImp;
 
     self.webView.scrollView.scrollEnabled = YES;
 
-    CGRect screen = [[UIScreen mainScreen] bounds];
+    CGRect screen = [[[UIApplication sharedApplication] keyWindow] frame];
     CGRect statusBar = [[UIApplication sharedApplication] statusBarFrame];
     CGRect keyboard = ((NSValue*)notif.userInfo[@"UIKeyboardFrameEndUserInfoKey"]).CGRectValue;
 


### PR DESCRIPTION
sometime the screen bounds doesn't match the application bounds.
e.g. the Splite View on iPad