### PR TITLE
Resolve bug where iOS 12 has a big black void under the content and above the keyboard

### DIFF
--- a/src/ios/CDVKeyboard.m
+++ b/src/ios/CDVKeyboard.m
@@ -195,12 +195,28 @@ static IMP WKOriginalImp;
     // The webview should always be able to return to full size
     CGRect keyboardIntersection = CGRectIntersection(screen, keyboard);
     if (CGRectContainsRect(screen, keyboardIntersection) && !CGRectIsEmpty(keyboardIntersection) && _shrinkView && self.keyboardIsVisible) {
-        screen.size.height -= keyboardIntersection.size.height;
-        self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView;
+        // I'm sure there's a better way...
+        if (@available(iOS 12, *)) {
+            self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView; // Order intentionally swapped.
+            screen.size.height -= keyboardIntersection.size.height;
+
+            CGSize revisedSize = CGSizeMake(self.webView.scrollView.frame.size.width, self.webView.scrollView.frame.size.height - keyboard.size.height);
+            self.webView.scrollView.contentSize = revisedSize;
+        }
+        else {
+            screen.size.height -= keyboardIntersection.size.height;
+            self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView;
+        }
     }
 
     // A view's frame is in its superview's coordinate system so we need to convert again
     self.webView.frame = [self.webView.superview convertRect:screen fromView:self.webView];
+
+    // I'm sure there's a better way...
+    if (@available(iOS 12, *)) {
+        CGSize revisedSize = CGSizeMake(self.webView.frame.size.width, self.webView.frame.size.height - keyboard.size.height);
+        self.webView.scrollView.contentSize = revisedSize;
+    }
 }
 
 #pragma mark UIScrollViewDelegate


### PR DESCRIPTION
Apply patch from @mattio

Gist: https://gist.github.com/mattio/ba5d77474e725463bc75cfbf1dba0cca
Comment: https://github.com/cjpearson/cordova-plugin-keyboard/issues/77#issuecomment-425554227